### PR TITLE
Show props

### DIFF
--- a/apps/storefront-docz/docs/index.mdx
+++ b/apps/storefront-docz/docs/index.mdx
@@ -5,11 +5,12 @@ route: /
 
 import { Playground, Props } from "docz"
 import { Typography } from "@equinor/eds-core-react"
+import PropsTable from "react-docgen-props-table"
 
 # Gaaaaaaaaaaaaaah
 
 <Typography variant="h4">Props</Typography>
-<Props of={Typography} />
+<PropsTable props={Typography.__docgenInfo.props} />
 
 <Playground>
   <Typography>Play with me</Typography>

--- a/apps/storefront-docz/package.json
+++ b/apps/storefront-docz/package.json
@@ -5,9 +5,10 @@
   "version": "0.1.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
+    "@emotion/core": "^10.0.28",
     "@equinor/eds-core-react": "workspace:*",
     "@equinor/eds-icons": "workspace:*",
-    "@emotion/core": "^10.0.28",
+    "@equinor/eds-tokens": "workspace:*",
     "@mdx-js/react": "^1.6.6",
     "@mikaelkristiansson/domready": "^1.0.10",
     "@reach/router": "^1.3.4",
@@ -28,10 +29,12 @@
     "prop-types": "^15.7.2",
     "query-string": "^6.13.1",
     "react": "^16.12.0",
+    "react-docgen-props-table": "^1.0.3",
     "react-dom": "^16.12.0",
     "react-error-overlay": "^6.0.7",
     "react-helmet": "^6.1.0",
-    "shallow-compare": "^1.2.2"
+    "shallow-compare": "^1.2.2",
+    "styled-components": "^5.1.1"
   },
   "devDependencies": {
     "prettier": "2.0.5"
@@ -42,7 +45,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
-    "develop": "gatsby develop",
+    "dev": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",

--- a/apps/storefront/Dockerfile
+++ b/apps/storefront/Dockerfile
@@ -24,7 +24,7 @@ RUN pnpm --filter ./libraries/tokens install && \
   pnpm --filter ./libraries/tokens run build
 
 RUN pnpm --filter ./libraries/core-react install && \
-  pnpm --filter ./libraries/core-react run build
+  pnpm --filter ./libraries/core-react run build:for-storybook
 
 RUN pnpm --filter ./apps/storefront install
 

--- a/libraries/core-react/rollup.config.js
+++ b/libraries/core-react/rollup.config.js
@@ -41,18 +41,14 @@ export default [
     ],
     output: [
       { file: pkg.browser, name: pkg.name, format: 'umd', globals },
-      ...(buildForStorybook
-        ? []
-        : [
-            {
-              file: pkg.module,
-              name: pkg.name,
-              format: 'esm',
-              sourcemap: 'inline',
-              globals,
-            },
-            { file: pkg.main, format: 'cjs' },
-          ]),
+      {
+        file: pkg.module,
+        name: pkg.name,
+        format: 'esm',
+        sourcemap: 'inline',
+        globals,
+      },
+      ...(buildForStorybook ? [] : [{ file: pkg.main, format: 'cjs' }]),
     ],
   },
 ]


### PR DESCRIPTION
- Builds es module as well as umd when running build:for-storybook
- Uses `react-docgen-props-table` to display props-table
- Changes `run develop` to `run dev`