### PR TITLE
fix: clear up some confusion

### DIFF
--- a/libraries/core-react/src/Scrim/Scrim.test.tsx
+++ b/libraries/core-react/src/Scrim/Scrim.test.tsx
@@ -27,7 +27,7 @@ const DismissableScrim = () => {
   }
 
   return visibleScrim ? (
-    <Scrim onKeyDown={handleClose}>
+    <Scrim onClose={handleClose} isDismissable={true}>
       <button type="button" onClick={() => setVisibleScrim(false)}>
         OK
       </button>
@@ -46,6 +46,17 @@ describe('Scrim', () => {
     fireEvent.click(targetButton)
     expect(scrim).not.toBeInTheDocument()
   })
+
+  it('Is dismissable with component click', () => {
+    const { container } = render(<DismissableScrim />)
+    const scrim = container.firstChild
+
+    expect(scrim).toBeInTheDocument()
+    expect(screen.queryByText('OK')).toBeVisible()
+    fireEvent.click(scrim)
+    expect(scrim).not.toBeInTheDocument()
+  })
+
   it('Is dismissable with Esc', () => {
     const { container } = render(<DismissableScrim />)
     const scrim = container.firstChild

--- a/libraries/core-react/src/Scrim/Scrim.tsx
+++ b/libraries/core-react/src/Scrim/Scrim.tsx
@@ -5,7 +5,6 @@ import { scrim as tokens } from './Scrim.tokens'
 const { height, width, background } = tokens
 
 type StyledScrimProps = {
-  onClose: (event: React.KeyboardEvent, open: boolean) => void
   onClick: (event: MouseEvent, open: boolean) => void
   isDismissable?: boolean
 }
@@ -38,8 +37,6 @@ type Props = {
     event: React.KeyboardEvent | MouseEvent | KeyboardEvent,
     open: boolean,
   ) => void
-  /** Stupid hack to avoid crash on ...re */
-  [x: string]: any
 }
 
 export const Scrim = forwardRef<HTMLDivElement, Props>(
@@ -78,7 +75,6 @@ export const Scrim = forwardRef<HTMLDivElement, Props>(
 
     return (
       <StyledScrim
-        onClose={handleKeyboardClose}
         onClick={handleMouseClose}
         isDismissable={isDismissable}
         {...rest}

--- a/libraries/core-react/src/Scrim/Scrim.tsx
+++ b/libraries/core-react/src/Scrim/Scrim.tsx
@@ -33,17 +33,12 @@ type Props = {
   /** Whether scrim can be dismissed with esc key */
   isDismissable?: boolean
   /** Function to handle closing scrim */
-  onClose?: (
-    event: React.KeyboardEvent | MouseEvent | KeyboardEvent,
-    open: boolean,
-  ) => void
+  onClose?: (event: MouseEvent | KeyboardEvent, open: boolean) => void
 }
 
 export const Scrim = forwardRef<HTMLDivElement, Props>(
   ({ children, onClose, isDismissable = false, ...rest }, ref) => {
-    const handleKeyboardClose = (
-      event: React.KeyboardEvent | KeyboardEvent,
-    ) => {
+    const handleKeyboardClose = (event: KeyboardEvent) => {
       if (event) {
         if (event.key === 'Escape' && isDismissable) {
           onClose && onClose(event, false)


### PR DESCRIPTION
If I understood the component correctly this fix should make more sense.

- Remove onClose from StyledScrimProps as its fully handle by Scrim component
- Remove obsolete `[x: string]: any`
- Add test for handleMouseClose() inside Scrim
- Set isDismissable on Scrim in tests
- Fix onClose/onKeyDown confusion in test
- Remove React.KeyboardEvent type from onClose

Let's have a further discussion about the types, as it is a bit hard to review without knowing the intended functionality when reviewing.